### PR TITLE
修正 \halign 计算宽度的错误

### DIFF
--- a/texk/ptex-ng/aptex-src.c
+++ b/texk/ptex-ng/aptex-src.c
@@ -23407,7 +23407,7 @@ static void fin_align (void)
       {
         add_glue_ref(zero_glue);
         delete_glue_ref(s);
-        glue_ptr(c) = zero_glue;
+        glue_ptr(r) = zero_glue;
       }
     }
 


### PR DESCRIPTION
见 TeX 源码 802 节，C 语言代码将变量 r 误抄成 c。
单步了好久才找到这里，晕。

fix clerkma/ptex-ng#7