### PR TITLE
Fix crash when take input from pipe

### DIFF
--- a/src/aptex-src.c
+++ b/src/aptex-src.c
@@ -40049,10 +40049,12 @@ void synctex_start_input (void)
     char * name_mbcs = utf8_mbcs(take_str_string(name));
 #ifdef USE_KPATHSEA
     synctex_root_name = kpse_find_file(name_mbcs, kpse_tex_format, false);
+    if (synctex_root_name == NULL)
+      synctex_root_name = name_mbcs;
+    else free(name_mbcs);
 #else
     synctex_root_name = name_mbcs;
 #endif
-    free(name_mbcs);
 
     if (!strlen(synctex_root_name))
     {


### PR DESCRIPTION
This bug happens when ptex-ng takes input from terminal and recive an `\input|"shellcmd ..."` command.

`kpse_find_file` would return `NULL` in that case, causing segfault on

    !strlen(synctex_root_name)

The `free(name_mbcs)` also should not happen when `synctex_root_name` is set directly to `name_mbcs`.

The crash can be reproduces by following procedure:

```
$ ptex-ng --shell-escape
This is Asiatic pTeX, Version 3.141592653 (preloaded format=ptex-ng)
**\relax
entering extended mode

*\input|"ls *.pdf"
```